### PR TITLE
Jenkinsのバージョンアップ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:1.625.1
+FROM jenkins:2.7.2
 MAINTAINER tsukasa.tamaru<tsukasa.tamaru@2dfacto.co.jp>
 
 USER root


### PR DESCRIPTION
honto用jenkinsのバージョンを最新版2.7.2に更新しました。